### PR TITLE
Patched binConverter.py

### DIFF
--- a/tools/binConverter.py
+++ b/tools/binConverter.py
@@ -24,7 +24,7 @@ def openFileToByte_generator(filename , chunkSize = 128):
                 break
 
 
-if(len(sys.argv) is not 2):
+if(len(sys.argv) != 2):
 	sys.exit('usage: binConverter.py "pathToFile\\fileName.bin"')
 
 fileIn = sys.argv[1]
@@ -40,7 +40,7 @@ print("reading file: " + fileIn)
 for byte in openFileToByte_generator(fileIn,16):
     countBytes += 1
     stringBuffer += "0x"+binascii.hexlify(byte).decode('ascii')+", "
-    if countBytes%16 is 0:
+    if countBytes%16 == 0:
     	stringBuffer += "\n\t"
 
 

--- a/tools/binConverter.py
+++ b/tools/binConverter.py
@@ -19,7 +19,10 @@ def openFileToByte_generator(filename , chunkSize = 128):
             printProgressBar(readBytes/float(fileSize))
             if chunk:
                 for byte in chunk:
-                    yield byte
+                     if sys.version_info[0] < 3:
+                        yield byte
+                    else:
+                        yield byte.to_bytes(1, byteorder='big')
             else:
                 break
 


### PR DESCRIPTION
Note: Not entirely my work, I think I got some help ages ago on sourceforge, but the syntax warnings fix was all me (it was easy what can you expect, got to take as much of the little amount of cred I can lol)

C:\...\Downloads>binConverter.py argon-nx.bin
C:\...\Downloads\binConverter.py:27: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if(len(sys.argv) is not 2):
C:\...\Downloads\binConverter.py:43: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if countBytes%16 is 0:
reading file: argon-nx.bin
[                    ] 0%Traceback (most recent call last):
  File "C:\...\Downloads\binConverter.py", line 42, in <module>
    stringBuffer += "0x"+binascii.hexlify(byte).decode('ascii')+", "
TypeError: a bytes-like object is required, not 'int'